### PR TITLE
Nissix plugin scope-packages on js-channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "bower-auto-release": "*",
     "wnpm-ci": "*"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "private": false,
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 10.522s



Output Log:
Migrating package "js-channel" in .


## Migration from non scope to @wix/scoped packages
> /tmp/5708bd564475ea871b00a67428534250

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

